### PR TITLE
added --watch flag to test command, fixes #12

### DIFF
--- a/commands/test/index.js
+++ b/commands/test/index.js
@@ -6,8 +6,8 @@ module.exports = (args) => {
     configFile: args.options.config ?
       path.resolve(process.cwd(), args.options.config) :
       path.join(__dirname, 'karma.conf.js'),
-    singleRun: true,
-    autoWatch: false
+    singleRun: !args.options.watch,
+    autoWatch: args.options.watch
   }, () => process.exit(0))
   .start();
 };

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
       "description": "Run the project's tests and generate coverage reports",
       "environment": "test",
       "options": {
-        "--config [file]": "Specify an alternate karma configuration to use"
+        "--config <file>": "Specify an alternate karma configuration to use",
+        "--watch": "Keep browser waiting for test re-runs and watch for file changes."
       }
     }
   ],


### PR DESCRIPTION
--watch flag enables webpack-dev-server to run in development mode