### PR TITLE
adding redux-logger as default middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "redux-devtools-dock-monitor": "1.1.1",
     "redux-devtools-log-monitor": "1.0.11",
     "redux-immutable": "3.0.6",
+    "redux-logger": "2.6.1",
     "redux-slider-monitor": "1.0.5",
     "sass-loader": "3.2.0",
     "style-loader": "0.13.1",


### PR DESCRIPTION
* loggerOptions can now be used to configure redux-logger middleware
* possible to also provide custom list of middleware, fixes #13